### PR TITLE
fix relative URLs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,7 +17,7 @@
     <div class="wrapper clearfix">
       <header class="clearfix">
         <a href="{{ site.baseurl }}">
-            <img src="{{ site.baseurl }}assets/fbopen.png"><br/><br/>
+            <img src="{{ site.baseurl }}/assets/fbopen.png"><br/><br/>
         <h1>FBOpen Docs</h1>
       </a>
         <p>FBOpen helps small businesses search for opportunities to work with the U.S. government.</p>

--- a/index.md
+++ b/index.md
@@ -7,9 +7,9 @@ published: true
 
 FBOpen is a search API of opportunities to work with the U.S. government.
 
-* View our [API documentation]({{ site.baseurl }}apidocs).
+* View our [API documentation]({{ site.baseurl }}/apidocs).
 * Visit the demo website: [fbopen.gsa.gov](https://fbopen.gsa.gov).
-* Learn more about the [data in FBOpen]({{ site.baseurl }}data-sources). _We're currently indexing data from FedBizOpps (including attachments) and Grants.gov._
+* Learn more about the [data in FBOpen]({{ site.baseurl }}/data-sources). _We're currently indexing data from FedBizOpps (including attachments) and Grants.gov._
 
 ### About the FBOpen API
 


### PR DESCRIPTION
@arowla This fixes a few URLs from the new config in https://github.com/18F/fbopen/pull/163. The site works for me at http://127.0.0.1:4000/fbopen/, though links like http://127.0.0.1:4000/fbopen/apidocs don't because the local Jekyll server doesn't handle missing file extensions like GitHub Pages does (http://18f.github.io/fbopen/apidocs). Hope that helps!
