### PR TITLE
Adds a partner agency

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -8,6 +8,8 @@ status: active
 stage: beta
 testable: true
 mission: 'To aggregate and make more accessible diverse opportunities to do business with the U.S. Government'
+partners:
+- General Services Administration
 links:
 - url: https://pages.18f.gov/fbopen
   text: FBOpen API Documentation


### PR DESCRIPTION
This field should reflect any agency that has or is still paying for work on the project. I'm pretty sure that was GSA but if not I'll change it.